### PR TITLE
Use a better black for background

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,7 +1,7 @@
 .output {
   padding: 20px;
   overflow: scroll;
-  background-color: black;
+  background-color: #1A1A1A;
   color: white;
 }
 


### PR DESCRIPTION
Pure white on pure black shouldn't be used. This will reduce headaches.
