### PR TITLE
fix content getting cut off vertically

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,5 +1,5 @@
 .output {
-  padding: 20px;
+  padding: 50px 20px;
   overflow: scroll;
   background-color: #1A1A1A;
   color: white;


### PR DESCRIPTION
The .output block does not scroll completely to the bottom or top. This will make the full content visible.
